### PR TITLE
Add options to count all types & skip old versions

### DIFF
--- a/usage.cfg
+++ b/usage.cfg
@@ -12,6 +12,7 @@ pwd=
 
 # The counts/bytes of these types per user will be aggregated.
 # Comma separated list of workspace types *without versions*. 
+# Set to * to process all types.
 types=KBaseNarrative.Narrative,KBaseFBA.FBAModel
 
 # A list of every workspace object of these types will be produced.


### PR DESCRIPTION
Can now
* set types=* in the config to count all types
* set a CLI flag to skip old versions of objects