### PR TITLE
Remove trailing newlines from script paths

### DIFF
--- a/.github/workflows/build_prodrc_pr.yaml
+++ b/.github/workflows/build_prodrc_pr.yaml
@@ -24,4 +24,4 @@ jobs:
         SHA: "${{ github.event.pull_request.head.sha }}"
         DOCKER_ACTOR: "jsfillman"
         DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
-      run: "./.github/workflows/scripts/build_prodrc_pr.sh\n"
+      run: "./.github/workflows/scripts/build_prodrc_pr.sh"

--- a/.github/workflows/build_test_pr.yaml
+++ b/.github/workflows/build_test_pr.yaml
@@ -24,4 +24,4 @@ jobs:
         SHA: "${{ github.event.pull_request.head.sha }}"
         DOCKER_ACTOR: "jsfillman"
         DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
-      run: "./.github/workflows/scripts/build_test_pr.sh\n"
+      run: "./.github/workflows/scripts/build_test_pr.sh"

--- a/.github/workflows/tag_test_latest.yaml
+++ b/.github/workflows/tag_test_latest.yaml
@@ -23,4 +23,4 @@ jobs:
         SHA: "${{ github.event.pull_request.head.sha }}"
         DOCKER_ACTOR: "jsfillman"
         DOCKER_TOKEN: "${{ secrets.GHCR_TOKEN }}"
-      run: "./.github/workflows/scripts/tag_test_latest.sh\n"
+      run: "./.github/workflows/scripts/tag_test_latest.sh"


### PR DESCRIPTION

   Had an issue with GHA giving "file not found" errors all of a sudden with the script, removing the trailing newline seemed to fix the issue. Going back and stripping them out from all of the workflows.